### PR TITLE
Update EsmtpTransport.php for TLS error when in SMTP mode

### DIFF
--- a/Transport/Smtp/EsmtpTransport.php
+++ b/Transport/Smtp/EsmtpTransport.php
@@ -106,7 +106,7 @@ class EsmtpTransport extends SmtpTransport
 
         /** @var SocketStream $stream */
         $stream = $this->getStream();
-        if (!$stream->isTLS() && \defined('OPENSSL_VERSION_NUMBER') && \array_key_exists('STARTTLS', $capabilities)) {
+        if ($stream->isTLS() && \defined('OPENSSL_VERSION_NUMBER') && \array_key_exists('STARTTLS', $capabilities)) {
             $this->executeCommand("STARTTLS\r\n", [220]);
 
             if (!$stream->startTLS()) {


### PR DESCRIPTION
I thinks that this condition is false. We should not call startTLS if we are not in TLS.
see symfony/symfony#36005

That's my first PR on symfony, so please say me if it's not the right way to do.