### PR TITLE
fixing send email when tls is disabled 6.0

### DIFF
--- a/DataCollector/MessageDataCollector.php
+++ b/DataCollector/MessageDataCollector.php
@@ -22,7 +22,7 @@ use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
  */
 final class MessageDataCollector extends DataCollector
 {
-    private MessageEvents $events;
+    private $events;
 
     public function __construct(MessageLoggerListener $logger)
     {

--- a/DataCollector/MessageDataCollector.php
+++ b/DataCollector/MessageDataCollector.php
@@ -22,7 +22,7 @@ use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
  */
 final class MessageDataCollector extends DataCollector
 {
-    private $events;
+    private MessageEvents $events;
 
     public function __construct(MessageLoggerListener $logger)
     {

--- a/DataCollector/MessageDataCollector.php
+++ b/DataCollector/MessageDataCollector.php
@@ -53,7 +53,7 @@ final class MessageDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'mailer';
     }

--- a/DelayedEnvelope.php
+++ b/DelayedEnvelope.php
@@ -25,7 +25,7 @@ final class DelayedEnvelope extends Envelope
 {
     private bool $senderSet = false;
     private bool $recipientsSet = false;
-    private Message $message;
+    private $message;
 
     public function __construct(Message $message)
     {

--- a/DelayedEnvelope.php
+++ b/DelayedEnvelope.php
@@ -23,9 +23,9 @@ use Symfony\Component\Mime\Message;
  */
 final class DelayedEnvelope extends Envelope
 {
-    private $senderSet = false;
-    private $recipientsSet = false;
-    private $message;
+    private bool $senderSet = false;
+    private bool $recipientsSet = false;
+    private Message $message;
 
     public function __construct(Message $message)
     {
@@ -52,7 +52,7 @@ final class DelayedEnvelope extends Envelope
     {
         parent::setRecipients($recipients);
 
-        $this->recipientsSet = parent::getRecipients();
+        $this->recipientsSet = (bool) parent::getRecipients();
     }
 
     /**

--- a/Envelope.php
+++ b/Envelope.php
@@ -21,7 +21,7 @@ use Symfony\Component\Mime\RawMessage;
  */
 class Envelope
 {
-    private Address $sender;
+    private $sender;
     private array $recipients = [];
 
     /**

--- a/Envelope.php
+++ b/Envelope.php
@@ -21,8 +21,8 @@ use Symfony\Component\Mime\RawMessage;
  */
 class Envelope
 {
-    private $sender;
-    private $recipients = [];
+    private Address $sender;
+    private array $recipients = [];
 
     /**
      * @param Address[] $recipients

--- a/Event/MessageEvent.php
+++ b/Event/MessageEvent.php
@@ -22,8 +22,8 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class MessageEvent extends Event
 {
-    private RawMessage $message;
-    private Envelope $envelope;
+    private $message;
+    private $envelope;
     private string $transport;
     private bool $queued;
 

--- a/Event/MessageEvent.php
+++ b/Event/MessageEvent.php
@@ -22,10 +22,10 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class MessageEvent extends Event
 {
-    private $message;
-    private $envelope;
-    private $transport;
-    private $queued;
+    private RawMessage $message;
+    private Envelope $envelope;
+    private string $transport;
+    private bool $queued;
 
     public function __construct(RawMessage $message, Envelope $envelope, string $transport, bool $queued = false)
     {

--- a/Event/MessageEvents.php
+++ b/Event/MessageEvents.php
@@ -18,8 +18,15 @@ use Symfony\Component\Mime\RawMessage;
  */
 class MessageEvents
 {
-    private $events = [];
-    private $transports = [];
+    /**
+     * @var MessageEvent[]
+     */
+    private array $events = [];
+
+    /**
+     * @var array<string, bool>
+     */
+    private array $transports = [];
 
     public function add(MessageEvent $event): void
     {

--- a/EventListener/EnvelopeListener.php
+++ b/EventListener/EnvelopeListener.php
@@ -23,7 +23,7 @@ use Symfony\Component\Mime\Message;
  */
 class EnvelopeListener implements EventSubscriberInterface
 {
-    private ?Address $sender = null;
+    private $sender = null;
 
     /**
      * @var Address[]|null

--- a/EventListener/EnvelopeListener.php
+++ b/EventListener/EnvelopeListener.php
@@ -27,10 +27,9 @@ class EnvelopeListener implements EventSubscriberInterface
     private $recipients;
 
     /**
-     * @param Address|string        $sender
      * @param array<Address|string> $recipients
      */
-    public function __construct($sender = null, array $recipients = null)
+    public function __construct(Address|string $sender = null, array $recipients = null)
     {
         if (null !== $sender) {
             $this->sender = Address::create($sender);

--- a/EventListener/EnvelopeListener.php
+++ b/EventListener/EnvelopeListener.php
@@ -23,8 +23,12 @@ use Symfony\Component\Mime\Message;
  */
 class EnvelopeListener implements EventSubscriberInterface
 {
-    private $sender;
-    private $recipients;
+    private ?Address $sender = null;
+
+    /**
+     * @var Address[]|null
+     */
+    private ?array $recipients = null;
 
     /**
      * @param array<Address|string> $recipients

--- a/EventListener/EnvelopeListener.php
+++ b/EventListener/EnvelopeListener.php
@@ -57,7 +57,7 @@ class EnvelopeListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             // should be the last one to allow header changes by other listeners first

--- a/EventListener/MessageListener.php
+++ b/EventListener/MessageListener.php
@@ -39,9 +39,9 @@ class MessageListener implements EventSubscriberInterface
         'bcc' => self::HEADER_ADD,
     ];
 
-    private ?Headers $headers;
+    private $headers;
     private array $headerRules = [];
-    private ?BodyRendererInterface $renderer;
+    private $renderer;
 
     public function __construct(Headers $headers = null, BodyRendererInterface $renderer = null, array $headerRules = self::DEFAULT_RULES)
     {

--- a/EventListener/MessageListener.php
+++ b/EventListener/MessageListener.php
@@ -125,7 +125,7 @@ class MessageListener implements EventSubscriberInterface
         $this->renderer->render($message);
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             MessageEvent::class => 'onMessage',

--- a/EventListener/MessageListener.php
+++ b/EventListener/MessageListener.php
@@ -39,9 +39,9 @@ class MessageListener implements EventSubscriberInterface
         'bcc' => self::HEADER_ADD,
     ];
 
-    private $headers;
-    private $headerRules = [];
-    private $renderer;
+    private ?Headers $headers;
+    private array $headerRules = [];
+    private ?BodyRendererInterface $renderer;
 
     public function __construct(Headers $headers = null, BodyRendererInterface $renderer = null, array $headerRules = self::DEFAULT_RULES)
     {

--- a/EventListener/MessageLoggerListener.php
+++ b/EventListener/MessageLoggerListener.php
@@ -23,7 +23,7 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 class MessageLoggerListener implements EventSubscriberInterface, ResetInterface
 {
-    private MessageEvents $events;
+    private $events;
 
     public function __construct()
     {

--- a/EventListener/MessageLoggerListener.php
+++ b/EventListener/MessageLoggerListener.php
@@ -23,7 +23,7 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 class MessageLoggerListener implements EventSubscriberInterface, ResetInterface
 {
-    private $events;
+    private MessageEvents $events;
 
     public function __construct()
     {

--- a/EventListener/MessageLoggerListener.php
+++ b/EventListener/MessageLoggerListener.php
@@ -48,7 +48,7 @@ class MessageLoggerListener implements EventSubscriberInterface, ResetInterface
         return $this->events;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             MessageEvent::class => ['onMessage', -255],

--- a/Exception/HttpTransportException.php
+++ b/Exception/HttpTransportException.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 class HttpTransportException extends TransportException
 {
-    private $response;
+    private ResponseInterface $response;
 
     public function __construct(string $message, ResponseInterface $response, int $code = 0, \Throwable $previous = null)
     {

--- a/Exception/HttpTransportException.php
+++ b/Exception/HttpTransportException.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 class HttpTransportException extends TransportException
 {
-    private ResponseInterface $response;
+    private $response;
 
     public function __construct(string $message, ResponseInterface $response, int $code = 0, \Throwable $previous = null)
     {

--- a/Exception/TransportException.php
+++ b/Exception/TransportException.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Mailer\Exception;
  */
 class TransportException extends RuntimeException implements TransportExceptionInterface
 {
-    private $debug = '';
+    private string $debug = '';
 
     public function getDebug(): string
     {

--- a/Header/MetadataHeader.php
+++ b/Header/MetadataHeader.php
@@ -18,7 +18,7 @@ use Symfony\Component\Mime\Header\UnstructuredHeader;
  */
 final class MetadataHeader extends UnstructuredHeader
 {
-    private $key;
+    private string $key;
 
     public function __construct(string $key, string $value)
     {

--- a/Mailer.php
+++ b/Mailer.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Mailer;
 
-use Symfony\Component\EventDispatcher\Event;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\Messenger\SendEmailMessage;
 use Symfony\Component\Mailer\Transport\TransportInterface;
@@ -33,7 +31,7 @@ final class Mailer implements MailerInterface
     {
         $this->transport = $transport;
         $this->bus = $bus;
-        $this->dispatcher = class_exists(Event::class) ? LegacyEventDispatcherProxy::decorate($dispatcher) : $dispatcher;
+        $this->dispatcher = $dispatcher;
     }
 
     public function send(RawMessage $message, Envelope $envelope = null): void

--- a/Mailer.php
+++ b/Mailer.php
@@ -23,9 +23,9 @@ use Symfony\Component\Mime\RawMessage;
  */
 final class Mailer implements MailerInterface
 {
-    private TransportInterface $transport;
-    private ?MessageBusInterface $bus;
-    private ?EventDispatcherInterface $dispatcher;
+    private $transport;
+    private $bus;
+    private $dispatcher;
 
     public function __construct(TransportInterface $transport, MessageBusInterface $bus = null, EventDispatcherInterface $dispatcher = null)
     {

--- a/Mailer.php
+++ b/Mailer.php
@@ -23,9 +23,9 @@ use Symfony\Component\Mime\RawMessage;
  */
 final class Mailer implements MailerInterface
 {
-    private $transport;
-    private $bus;
-    private $dispatcher;
+    private TransportInterface $transport;
+    private ?MessageBusInterface $bus;
+    private ?EventDispatcherInterface $dispatcher;
 
     public function __construct(TransportInterface $transport, MessageBusInterface $bus = null, EventDispatcherInterface $dispatcher = null)
     {

--- a/Messenger/MessageHandler.php
+++ b/Messenger/MessageHandler.php
@@ -19,7 +19,7 @@ use Symfony\Component\Mailer\Transport\TransportInterface;
  */
 class MessageHandler
 {
-    private $transport;
+    private TransportInterface $transport;
 
     public function __construct(TransportInterface $transport)
     {

--- a/Messenger/MessageHandler.php
+++ b/Messenger/MessageHandler.php
@@ -19,7 +19,7 @@ use Symfony\Component\Mailer\Transport\TransportInterface;
  */
 class MessageHandler
 {
-    private TransportInterface $transport;
+    private $transport;
 
     public function __construct(TransportInterface $transport)
     {

--- a/Messenger/SendEmailMessage.php
+++ b/Messenger/SendEmailMessage.php
@@ -19,8 +19,8 @@ use Symfony\Component\Mime\RawMessage;
  */
 class SendEmailMessage
 {
-    private $message;
-    private $envelope;
+    private RawMessage $message;
+    private ?Envelope $envelope;
 
     public function __construct(RawMessage $message, Envelope $envelope = null)
     {

--- a/Messenger/SendEmailMessage.php
+++ b/Messenger/SendEmailMessage.php
@@ -19,8 +19,8 @@ use Symfony\Component\Mime\RawMessage;
  */
 class SendEmailMessage
 {
-    private RawMessage $message;
-    private ?Envelope $envelope;
+    private $message;
+    private $envelope;
 
     public function __construct(RawMessage $message, Envelope $envelope = null)
     {

--- a/SentMessage.php
+++ b/SentMessage.php
@@ -19,9 +19,9 @@ use Symfony\Component\Mime\RawMessage;
  */
 class SentMessage
 {
-    private RawMessage $original;
-    private RawMessage $raw;
-    private Envelope $envelope;
+    private $original;
+    private $raw;
+    private $envelope;
     private string $messageId;
     private string $debug = '';
 

--- a/SentMessage.php
+++ b/SentMessage.php
@@ -19,11 +19,11 @@ use Symfony\Component\Mime\RawMessage;
  */
 class SentMessage
 {
-    private $original;
-    private $raw;
-    private $envelope;
-    private $messageId;
-    private $debug = '';
+    private RawMessage $original;
+    private RawMessage $raw;
+    private Envelope $envelope;
+    private string $messageId;
+    private string $debug = '';
 
     /**
      * @internal

--- a/Test/Constraint/EmailCount.php
+++ b/Test/Constraint/EmailCount.php
@@ -16,9 +16,9 @@ use Symfony\Component\Mailer\Event\MessageEvents;
 
 final class EmailCount extends Constraint
 {
-    private $expectedValue;
-    private $transport;
-    private $queued;
+    private int $expectedValue;
+    private ?string $transport;
+    private bool $queued;
 
     public function __construct(int $expectedValue, string $transport = null, bool $queued = false)
     {

--- a/Transport.php
+++ b/Transport.php
@@ -42,14 +42,14 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 class Transport
 {
     private const FACTORY_CLASSES = [
-        SesTransportFactory::class,
         GmailTransportFactory::class,
-        MandrillTransportFactory::class,
         MailgunTransportFactory::class,
+        MailjetTransportFactory::class,
+        MandrillTransportFactory::class,
         PostmarkTransportFactory::class,
         SendgridTransportFactory::class,
-        MailjetTransportFactory::class,
         SendinblueTransportFactory::class,
+        SesTransportFactory::class,
     ];
 
     private $factories;

--- a/Transport.php
+++ b/Transport.php
@@ -54,7 +54,7 @@ final class Transport
         SesTransportFactory::class,
     ];
 
-    private $factories;
+    private iterable $factories;
 
     public static function fromDsn(string $dsn, EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null): TransportInterface
     {

--- a/Transport.php
+++ b/Transport.php
@@ -38,10 +38,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Konstantin Myakshin <molodchick@gmail.com>
- *
- * @final since Symfony 5.4
  */
-class Transport
+final class Transport
 {
     private const FACTORY_CLASSES = [
         GmailTransportFactory::class,
@@ -56,33 +54,15 @@ class Transport
 
     private $factories;
 
-    /**
-     * @param EventDispatcherInterface|null $dispatcher
-     * @param HttpClientInterface|null      $client
-     * @param LoggerInterface|null          $logger
-     */
-    public static function fromDsn(string $dsn/*, EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null*/): TransportInterface
+    public static function fromDsn(string $dsn, EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null): TransportInterface
     {
-        $dispatcher = 2 <= \func_num_args() ? func_get_arg(1) : null;
-        $client = 3 <= \func_num_args() ? func_get_arg(2) : null;
-        $logger = 4 <= \func_num_args() ? func_get_arg(3) : null;
-
         $factory = new self(iterator_to_array(self::getDefaultFactories($dispatcher, $client, $logger)));
 
         return $factory->fromString($dsn);
     }
 
-    /**
-     * @param EventDispatcherInterface|null $dispatcher
-     * @param HttpClientInterface|null      $client
-     * @param LoggerInterface|null          $logger
-     */
-    public static function fromDsns(array $dsns/*, EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null*/): TransportInterface
+    public static function fromDsns(array $dsns, EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null): TransportInterface
     {
-        $dispatcher = 2 <= \func_num_args() ? func_get_arg(1) : null;
-        $client = 3 <= \func_num_args() ? func_get_arg(2) : null;
-        $logger = 4 <= \func_num_args() ? func_get_arg(3) : null;
-
         $factory = new self(iterator_to_array(self::getDefaultFactories($dispatcher, $client, $logger)));
 
         return $factory->fromStrings($dsns);
@@ -175,18 +155,10 @@ class Transport
     }
 
     /**
-     * @param EventDispatcherInterface|null $dispatcher
-     * @param HttpClientInterface|null      $client
-     * @param LoggerInterface|null          $logger
-     *
      * @return \Traversable<int, TransportFactoryInterface>
      */
-    public static function getDefaultFactories(/*EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null*/): iterable
+    public static function getDefaultFactories(EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null): \Traversable
     {
-        $dispatcher = 1 <= \func_num_args() ? func_get_arg(0) : null;
-        $client = 2 <= \func_num_args() ? func_get_arg(1) : null;
-        $logger = 3 <= \func_num_args() ? func_get_arg(2) : null;
-
         foreach (self::FACTORY_CLASSES as $factoryClass) {
             if (class_exists($factoryClass)) {
                 yield new $factoryClass($dispatcher, $client, $logger);

--- a/Transport/AbstractHttpTransport.php
+++ b/Transport/AbstractHttpTransport.php
@@ -45,7 +45,7 @@ abstract class AbstractHttpTransport extends AbstractTransport
     /**
      * @return $this
      */
-    public function setHost(?string $host)
+    public function setHost(?string $host): static
     {
         $this->host = $host;
 
@@ -55,7 +55,7 @@ abstract class AbstractHttpTransport extends AbstractTransport
     /**
      * @return $this
      */
-    public function setPort(?int $port)
+    public function setPort(?int $port): static
     {
         $this->port = $port;
 

--- a/Transport/AbstractTransport.php
+++ b/Transport/AbstractTransport.php
@@ -25,8 +25,8 @@ use Symfony\Component\Mime\RawMessage;
  */
 abstract class AbstractTransport implements TransportInterface
 {
-    private ?EventDispatcherInterface $dispatcher;
-    private LoggerInterface $logger;
+    private $dispatcher;
+    private $logger;
     private float $rate = 0;
     private float $lastSent = 0;
 

--- a/Transport/AbstractTransport.php
+++ b/Transport/AbstractTransport.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\Mailer\Transport;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\EventDispatcher\Event;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\SentMessage;
@@ -34,7 +32,7 @@ abstract class AbstractTransport implements TransportInterface
 
     public function __construct(EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        $this->dispatcher = class_exists(Event::class) ? LegacyEventDispatcherProxy::decorate($dispatcher) : $dispatcher;
+        $this->dispatcher = $dispatcher;
         $this->logger = $logger ?? new NullLogger();
     }
 

--- a/Transport/AbstractTransport.php
+++ b/Transport/AbstractTransport.php
@@ -25,10 +25,10 @@ use Symfony\Component\Mime\RawMessage;
  */
 abstract class AbstractTransport implements TransportInterface
 {
-    private $dispatcher;
-    private $logger;
-    private $rate = 0;
-    private $lastSent = 0;
+    private ?EventDispatcherInterface $dispatcher;
+    private LoggerInterface $logger;
+    private float $rate = 0;
+    private int $lastSent = 0;
 
     public function __construct(EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {

--- a/Transport/AbstractTransport.php
+++ b/Transport/AbstractTransport.php
@@ -28,7 +28,7 @@ abstract class AbstractTransport implements TransportInterface
     private ?EventDispatcherInterface $dispatcher;
     private LoggerInterface $logger;
     private float $rate = 0;
-    private int $lastSent = 0;
+    private float $lastSent = 0;
 
     public function __construct(EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {

--- a/Transport/AbstractTransport.php
+++ b/Transport/AbstractTransport.php
@@ -41,7 +41,7 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @return $this
      */
-    public function setMaxPerSecond(float $rate): self
+    public function setMaxPerSecond(float $rate): static
     {
         if (0 >= $rate) {
             $rate = 0;

--- a/Transport/Dsn.php
+++ b/Transport/Dsn.php
@@ -82,7 +82,7 @@ final class Dsn
         return $this->port ?? $default;
     }
 
-    public function getOption(string $key, $default = null)
+    public function getOption(string $key, mixed $default = null)
     {
         return $this->options[$key] ?? $default;
     }

--- a/Transport/Dsn.php
+++ b/Transport/Dsn.php
@@ -18,12 +18,12 @@ use Symfony\Component\Mailer\Exception\InvalidArgumentException;
  */
 final class Dsn
 {
-    private $scheme;
-    private $host;
-    private $user;
-    private $password;
-    private $port;
-    private $options;
+    private string $scheme;
+    private string $host;
+    private ?string $user;
+    private ?string $password;
+    private ?int $port;
+    private array $options;
 
     public function __construct(string $scheme, string $host, string $user = null, string $password = null, int $port = null, array $options = [])
     {

--- a/Transport/FailoverTransport.php
+++ b/Transport/FailoverTransport.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Mailer\Transport;
  */
 class FailoverTransport extends RoundRobinTransport
 {
-    private ?TransportInterface $currentTransport = null;
+    private $currentTransport = null;
 
     protected function getNextTransport(): ?TransportInterface
     {

--- a/Transport/FailoverTransport.php
+++ b/Transport/FailoverTransport.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Mailer\Transport;
  */
 class FailoverTransport extends RoundRobinTransport
 {
-    private $currentTransport;
+    private ?TransportInterface $currentTransport = null;
 
     protected function getNextTransport(): ?TransportInterface
     {

--- a/Transport/RoundRobinTransport.php
+++ b/Transport/RoundRobinTransport.php
@@ -24,10 +24,10 @@ use Symfony\Component\Mime\RawMessage;
  */
 class RoundRobinTransport implements TransportInterface
 {
-    private $deadTransports;
-    private $transports = [];
-    private $retryPeriod;
-    private $cursor = -1;
+    private \SplObjectStorage $deadTransports;
+    private array $transports = [];
+    private int $retryPeriod;
+    private int $cursor = -1;
 
     /**
      * @param TransportInterface[] $transports

--- a/Transport/SendmailTransport.php
+++ b/Transport/SendmailTransport.php
@@ -37,9 +37,9 @@ use Symfony\Component\Mime\RawMessage;
  */
 class SendmailTransport extends AbstractTransport
 {
-    private $command = '/usr/sbin/sendmail -bs';
-    private $stream;
-    private $transport;
+    private string $command = '/usr/sbin/sendmail -bs';
+    private ProcessStream $stream;
+    private ?SmtpTransport $transport = null;
 
     /**
      * Constructor.

--- a/Transport/SendmailTransport.php
+++ b/Transport/SendmailTransport.php
@@ -38,8 +38,8 @@ use Symfony\Component\Mime\RawMessage;
 class SendmailTransport extends AbstractTransport
 {
     private string $command = '/usr/sbin/sendmail -bs';
-    private ProcessStream $stream;
-    private ?SmtpTransport $transport = null;
+    private $stream;
+    private $transport = null;
 
     /**
      * Constructor.

--- a/Transport/Smtp/EsmtpTransport.php
+++ b/Transport/Smtp/EsmtpTransport.php
@@ -26,9 +26,9 @@ use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
  */
 class EsmtpTransport extends SmtpTransport
 {
-    private $authenticators = [];
-    private $username = '';
-    private $password = '';
+    private array $authenticators = [];
+    private string $username = '';
+    private string $password = '';
 
     public function __construct(string $host = 'localhost', int $port = 0, bool $tls = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {

--- a/Transport/Smtp/EsmtpTransport.php
+++ b/Transport/Smtp/EsmtpTransport.php
@@ -66,7 +66,7 @@ class EsmtpTransport extends SmtpTransport
     /**
      * @return $this
      */
-    public function setUsername(string $username): self
+    public function setUsername(string $username): static
     {
         $this->username = $username;
 
@@ -81,7 +81,7 @@ class EsmtpTransport extends SmtpTransport
     /**
      * @return $this
      */
-    public function setPassword(string $password): self
+    public function setPassword(string $password): static
     {
         $this->password = $password;
 

--- a/Transport/Smtp/SmtpTransport.php
+++ b/Transport/Smtp/SmtpTransport.php
@@ -36,7 +36,7 @@ class SmtpTransport extends AbstractTransport
     private int $restartThresholdSleep = 0;
     private int $restartCounter = 0;
     private int $pingThreshold = 100;
-    private int $lastMessageTime = 0;
+    private float $lastMessageTime = 0;
     private AbstractStream $stream;
     private string $domain = '[127.0.0.1]';
 

--- a/Transport/Smtp/SmtpTransport.php
+++ b/Transport/Smtp/SmtpTransport.php
@@ -83,7 +83,7 @@ class SmtpTransport extends AbstractTransport
      *
      * @return $this
      */
-    public function setPingThreshold(int $seconds): self
+    public function setPingThreshold(int $seconds): static
     {
         $this->pingThreshold = $seconds;
 
@@ -343,7 +343,7 @@ class SmtpTransport extends AbstractTransport
     /**
      * @return array
      */
-    public function __sleep()
+    public function __sleep(): array
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }

--- a/Transport/Smtp/SmtpTransport.php
+++ b/Transport/Smtp/SmtpTransport.php
@@ -62,7 +62,7 @@ class SmtpTransport extends AbstractTransport
      *
      * @return $this
      */
-    public function setRestartThreshold(int $threshold, int $sleep = 0): self
+    public function setRestartThreshold(int $threshold, int $sleep = 0): static
     {
         $this->restartThreshold = $threshold;
         $this->restartThresholdSleep = $sleep;
@@ -104,7 +104,7 @@ class SmtpTransport extends AbstractTransport
      *
      * @return $this
      */
-    public function setLocalDomain(string $domain): self
+    public function setLocalDomain(string $domain): static
     {
         if ('' !== $domain && '[' !== $domain[0]) {
             if (filter_var($domain, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4)) {

--- a/Transport/Smtp/SmtpTransport.php
+++ b/Transport/Smtp/SmtpTransport.php
@@ -340,9 +340,6 @@ class SmtpTransport extends AbstractTransport
         $this->restartCounter = 0;
     }
 
-    /**
-     * @return array
-     */
     public function __sleep(): array
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/Transport/Smtp/SmtpTransport.php
+++ b/Transport/Smtp/SmtpTransport.php
@@ -37,7 +37,7 @@ class SmtpTransport extends AbstractTransport
     private int $restartCounter = 0;
     private int $pingThreshold = 100;
     private float $lastMessageTime = 0;
-    private AbstractStream $stream;
+    private $stream;
     private string $domain = '[127.0.0.1]';
 
     public function __construct(AbstractStream $stream = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)

--- a/Transport/Smtp/SmtpTransport.php
+++ b/Transport/Smtp/SmtpTransport.php
@@ -31,14 +31,14 @@ use Symfony\Component\Mime\RawMessage;
  */
 class SmtpTransport extends AbstractTransport
 {
-    private $started = false;
-    private $restartThreshold = 100;
-    private $restartThresholdSleep = 0;
-    private $restartCounter;
-    private $pingThreshold = 100;
-    private $lastMessageTime = 0;
-    private $stream;
-    private $domain = '[127.0.0.1]';
+    private bool $started = false;
+    private int $restartThreshold = 100;
+    private int $restartThresholdSleep = 0;
+    private int $restartCounter = 0;
+    private int $pingThreshold = 100;
+    private int $lastMessageTime = 0;
+    private AbstractStream $stream;
+    private string $domain = '[127.0.0.1]';
 
     public function __construct(AbstractStream $stream = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {

--- a/Transport/Smtp/Stream/AbstractStream.php
+++ b/Transport/Smtp/Stream/AbstractStream.php
@@ -28,7 +28,7 @@ abstract class AbstractStream
     protected $in;
     protected $out;
 
-    private $debug = '';
+    private string $debug = '';
 
     public function write(string $bytes, bool $debug = true): void
     {

--- a/Transport/Smtp/Stream/ProcessStream.php
+++ b/Transport/Smtp/Stream/ProcessStream.php
@@ -23,7 +23,7 @@ use Symfony\Component\Mailer\Exception\TransportException;
  */
 final class ProcessStream extends AbstractStream
 {
-    private $command;
+    private string $command;
 
     public function setCommand(string $command)
     {

--- a/Transport/Smtp/Stream/SocketStream.php
+++ b/Transport/Smtp/Stream/SocketStream.php
@@ -23,13 +23,13 @@ use Symfony\Component\Mailer\Exception\TransportException;
  */
 final class SocketStream extends AbstractStream
 {
-    private $url;
-    private $host = 'localhost';
-    private $port = 465;
-    private $timeout;
-    private $tls = true;
-    private $sourceIp;
-    private $streamContextOptions = [];
+    private string $url;
+    private string $host = 'localhost';
+    private int $port = 465;
+    private float $timeout;
+    private bool $tls = true;
+    private ?string $sourceIp = null;
+    private array $streamContextOptions = [];
 
     public function setTimeout(float $timeout): self
     {

--- a/Transport/Smtp/Stream/SocketStream.php
+++ b/Transport/Smtp/Stream/SocketStream.php
@@ -34,7 +34,7 @@ final class SocketStream extends AbstractStream
     /**
      * @return $this
      */
-    public function setTimeout(float $timeout): self
+    public function setTimeout(float $timeout): static
     {
         $this->timeout = $timeout;
 
@@ -51,7 +51,7 @@ final class SocketStream extends AbstractStream
      *
      * @return $this
      */
-    public function setHost(string $host): self
+    public function setHost(string $host): static
     {
         $this->host = $host;
 
@@ -66,7 +66,7 @@ final class SocketStream extends AbstractStream
     /**
      * @return $this
      */
-    public function setPort(int $port): self
+    public function setPort(int $port): static
     {
         $this->port = $port;
 
@@ -83,7 +83,7 @@ final class SocketStream extends AbstractStream
      *
      * @return $this
      */
-    public function disableTls(): self
+    public function disableTls(): static
     {
         $this->tls = false;
 
@@ -98,7 +98,7 @@ final class SocketStream extends AbstractStream
     /**
      * @return $this
      */
-    public function setStreamOptions(array $options): self
+    public function setStreamOptions(array $options): static
     {
         $this->streamContextOptions = $options;
 
@@ -117,7 +117,7 @@ final class SocketStream extends AbstractStream
      *
      * @return $this
      */
-    public function setSourceIp(string $ip): self
+    public function setSourceIp(string $ip): static
     {
         $this->sourceIp = $ip;
 

--- a/Transport/Transports.php
+++ b/Transport/Transports.php
@@ -27,7 +27,7 @@ final class Transports implements TransportInterface
      * @var array<string, TransportInterface>
      */
     private array $transports = [];
-    private TransportInterface $default;
+    private $default;
 
     /**
      * @param iterable<string, TransportInterface> $transports

--- a/Transport/Transports.php
+++ b/Transport/Transports.php
@@ -23,19 +23,19 @@ use Symfony\Component\Mime\RawMessage;
  */
 final class Transports implements TransportInterface
 {
-    private $transports;
-    private $default;
+    /**
+     * @var array<string, TransportInterface>
+     */
+    private array $transports = [];
+    private TransportInterface $default;
 
     /**
-     * @param TransportInterface[] $transports
+     * @param iterable<string, TransportInterface> $transports
      */
     public function __construct(iterable $transports)
     {
-        $this->transports = [];
         foreach ($transports as $name => $transport) {
-            if (null === $this->default) {
-                $this->default = $transport;
-            }
+            $this->default ??= $transport;
             $this->transports[$name] = $transport;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
         "psr/log": "~1.0",
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/mime": "^5.4|^6.0",
-        "symfony/service-contracts": "^1.1|^2"
+        "symfony/service-contracts": "^1.1|^2.0|^3.0"
     },
     "require-dev": {
-        "symfony/http-client-contracts": "^1.1|^2",
+        "symfony/http-client-contracts": "^1.1|^2.0|^3.0",
         "symfony/messenger": "^5.4|^6.0"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,16 @@
         "php": ">=8.0.2",
         "egulias/email-validator": "^2.1.10|^3",
         "psr/log": "~1.0",
-        "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
-        "symfony/mime": "^5.2.6|^6.0",
+        "symfony/event-dispatcher": "^5.4|^6.0",
+        "symfony/mime": "^5.4|^6.0",
         "symfony/service-contracts": "^1.1|^2"
     },
     "require-dev": {
         "symfony/http-client-contracts": "^1.1|^2",
-        "symfony/messenger": "^4.4|^5.0|^6.0"
+        "symfony/messenger": "^5.4|^6.0"
     },
     "conflict": {
-        "symfony/http-kernel": "<4.4"
+        "symfony/http-kernel": "<5.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\": "" },

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,11 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.0.2",
         "egulias/email-validator": "^2.1.10|^3",
         "psr/log": "~1.0",
         "symfony/event-dispatcher": "^4.4|^5.0",
         "symfony/mime": "^5.2.6",
-        "symfony/polyfill-php80": "^1.15",
         "symfony/service-contracts": "^1.1|^2"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.3/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
@@ -18,13 +18,13 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
// WARNING: !$stream->isTLS() is right, 100% sure :)
        // if you think that the ! should be removed, read the code again
        // if doing so "fixes" your issue then it probably means your SMTP server behaves incorrectly or is wrongly configured

in order to send mail when ssl disabled ,we shoud set the condition as : 

`if ($stream->isTLS() && \defined('OPENSSL_VERSION_NUMBER') && \array_key_exists('STARTTLS', $capabilities))`