### PR TITLE
[Mailer] Handle missed sender name

### DIFF
--- a/EventListener/EnvelopeListener.php
+++ b/EventListener/EnvelopeListener.php
@@ -48,7 +48,7 @@ class EnvelopeListener implements EventSubscriberInterface
             $message = $event->getMessage();
             if ($message instanceof Message) {
                 if (!$message->getHeaders()->has('Sender') && !$message->getHeaders()->has('From')) {
-                    $message->getHeaders()->addMailboxHeader('Sender', $this->sender->getAddress());
+                    $message->getHeaders()->addMailboxHeader('Sender', $this->sender);
                 }
             }
         }


### PR DESCRIPTION
- [x] bug fix

Fix missed sender name in case with usage of the EnvelopeListener

```
$eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
$eventDispatcher->addSubscriber(
    new \Symfony\Component\Mailer\EventListener\EnvelopeListener(
        new \Symfony\Component\Mime\Address('noreply@test.com', 'TestName')
    )
);
```