### PR TITLE
Removing unneeded mode checking in SendmailTransport

### DIFF
--- a/Transport/SendmailTransport.php
+++ b/Transport/SendmailTransport.php
@@ -54,10 +54,6 @@ class SendmailTransport extends AbstractTransport
         parent::__construct($dispatcher, $logger);
 
         if (null !== $command) {
-            if (!str_contains($command, ' -bs') && !str_contains($command, ' -t')) {
-                throw new \InvalidArgumentException(sprintf('Unsupported sendmail command flags "%s"; must be one of "-bs" or "-t" but can include additional flags.', $command));
-            }
-
             $this->command = $command;
         }
 


### PR DESCRIPTION
The mode checking and exception has been there since this class started in Swiftmailer:
https://github.com/swiftmailer/swiftmailer/commit/de5f2f984e03441d3f7c2b10737e9d80ef3bae4f#diff-ab3f44d17819352e5340cebcc66a104a2c60ae6a389cbc012d6d13625cd2b870R87

It's caused trouble in combination with environment specific scripts that capture or parse mail with overridden `ini_get('sendmail_path')` like mailhog in my case or we use a custom script that eats mail in our staging environments.

Here's more context and details around the problem:
https://www.drupal.org/project/symfony_mailer/issues/3277333#comment-14619079
https://www.drupal.org/project/swiftmailer/issues/3174215

I'm creating this PR against 6.1 but we are using `"symfony/mailer": "^5.3.0",` in Drupal, not sure if this will get in 5.x, but maybe this will help future us 😅