### PR TITLE
STDOUT blocks infinitely under Windows when STDERR is filled

### DIFF
--- a/Transport/Smtp/Stream/ProcessStream.php
+++ b/Transport/Smtp/Stream/ProcessStream.php
@@ -35,7 +35,7 @@ final class ProcessStream extends AbstractStream
         $descriptorSpec = [
             0 => ['pipe', 'r'],
             1 => ['pipe', 'w'],
-            2 => ['pipe', 'w'],
+            2 => ['pipe', 'a'],
         ];
         $pipes = [];
         $this->stream = proc_open($this->command, $descriptorSpec, $pipes);


### PR DESCRIPTION
stream_get_contents() on STDOUT blocks infinitely under Windows when STDERR is filled under some circumstances. Open STDERR in append mode ("a"), then this will work.